### PR TITLE
Circle ci dev

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+machine:
+  java:
+    version: openjdk8

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   java:
-    version: openjdk8
+    version: oraclejdk8

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,10 @@
 machine:
   java:
     version: oraclejdk8
+
+deployment:
+  demo:
+    branch: circle-ci-dev
+    commands:
+      - cd $HOME/$CIRCLE_PROJECT_REPONAME && mvn package
+      - gsutil cp $HOME/$CIRCLE_PROJECT_REPONAME/target/angleddream-bundled-0.1-ALPHA.jar gs://build-artifacts-public-eu/angleddream-bundled.jar


### PR DESCRIPTION
only had to specify the java version

eventually this file will be responsible for persisting the output jar to somewhere so other projects can go get it.  or maybe we leave that to maven, I dunno.  I'm not your boss.
